### PR TITLE
trim output of tag for console-ouput

### DIFF
--- a/Classes/ActiveViewHelpers/DebugViewHelper.php
+++ b/Classes/ActiveViewHelpers/DebugViewHelper.php
@@ -107,7 +107,7 @@ class DebugViewHelper extends AbstractViewHelper
                     'Line %d, character %d: %s',
                     $pointers[0],
                     $pointers[1],
-                    $pointers[2]
+                    trim($pointers[2])
                 );
             }
             if (TYPO3_MODE === 'FE') {


### PR DESCRIPTION
In the output of the debug-view-helper, the tag-output contained
PHP_EOLs breaking the JS-Code (TYPO3 8.7.16). Trimming makes the JS-Code valid